### PR TITLE
Cải thiện quét hộ chiếu trong vùng overlay

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,6 +49,22 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintWidth_percent="0.9"/>
 
+    <!-- 3b. OCR Debug Panel: Hiển thị các dòng IN/OUT để kiểm tra ROI -->
+    <TextView
+        android:id="@+id/ocrDebugText"
+        android:layout_width="0dp"
+        android:layout_height="120dp"
+        android:layout_marginTop="8dp"
+        android:background="#4D000000"
+        android:textColor="@android:color/white"
+        android:textSize="12sp"
+        android:padding="8dp"
+        android:scrollbars="vertical"
+        app:layout_constraintTop_toBottomOf="@id/statusText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintWidth_percent="0.9"/>
+
     <!-- 4. Torch toggle: simple square tap target in top-right -->
     <View
         android:id="@+id/torchToggle"


### PR DESCRIPTION
Add ROI-focused OCR and a live debug view to improve scanning and verify text processing within the frame.

The previous implementation had a 0% success rate for passport scanning. This PR restricts OCR processing to the visible yellow overlay frame, preventing irrelevant text from interfering with MRZ detection. A new debug panel displays all detected OCR lines, explicitly marking whether they fall `[IN]` or `[OUT]` of the ROI, aiding in verifying ROI mapping and OCR behavior. `PreviewView` scaling and coordinate mapping logic were also corrected for accurate ROI calculation across device orientations.

---
<a href="https://cursor.com/background-agent?bcId=bc-08d8fa69-3d22-4da5-81fe-02a4a47cfb2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08d8fa69-3d22-4da5-81fe-02a4a47cfb2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

