### PR TITLE
Improve passport scan accuracy and panel position

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,21 +49,22 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintWidth_percent="0.9"/>
 
-    <!-- 3b. OCR Debug Panel: Hiển thị các dòng IN/OUT để kiểm tra ROI -->
+    <!-- 3b. OCR Debug Panel: Đưa lên đầu màn hình để dễ theo dõi -->
     <TextView
         android:id="@+id/ocrDebugText"
         android:layout_width="0dp"
         android:layout_height="120dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
         android:background="#4D000000"
         android:textColor="@android:color/white"
         android:textSize="12sp"
         android:padding="8dp"
         android:scrollbars="vertical"
-        app:layout_constraintTop_toBottomOf="@id/statusText"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintWidth_percent="0.9"/>
+        app:layout_constraintEnd_toStartOf="@id/torchToggle"/>
 
     <!-- 4. Torch toggle: simple square tap target in top-right -->
     <View


### PR DESCRIPTION
Restrict MRZ scanning to the `mrz_guide_frame` and move the OCR Debug Panel to the top for better visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-09c4c3a7-d04e-4cd6-95e9-8b2fd0cc10ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09c4c3a7-d04e-4cd6-95e9-8b2fd0cc10ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

